### PR TITLE
turn /friends/follow into POST request

### DIFF
--- a/app/views/friends/_table.html.haml
+++ b/app/views/friends/_table.html.haml
@@ -5,6 +5,6 @@
 
     - if user.mastodon
       .mastodon= link_to user.mastodon.uid, mastodon_profile_url(user.mastodon.uid)
-      .follow= link_to "Follow", follow_friend_path(user), class: 'button'
+      .follow= button_to "Follow", follow_friend_path(user), class: 'button'
     - else
       .mastodon Unknown, yet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   resources :friends, only: :index do
     member do
-      get :follow
+      post :follow
     end
   end
 


### PR DESCRIPTION
Otherwise users could be forced to unwittingly follow users by embedding a follow link on a third party site.

For example embedding https://mastodon-bridge.herokuapp.com/friends/4512/follow as an image somewhere will cause you to follow me as soon as the page loads, without you knowing, when you're logged in to mastodon-bridge.